### PR TITLE
change header keywords

### DIFF
--- a/outline-magic.el
+++ b/outline-magic.el
@@ -2,8 +2,8 @@
 
 ;; Copyright (C) 2002, 2013 Carsten Dominik, Thorsten Jolitz
 
-;; Original Maintainer: Carsten Dominik <dominik@science.uva.nl>
-;; New Maintainer: Thorsten Jolitz <tjolitz AT gmail DOT com>
+;; Author: Carsten Dominik <dominik@science.uva.nl>
+;; Maintainer: Thorsten Jolitz <tjolitz AT gmail DOT com>
 ;; Version: 0.9.1
 ;; Keywords: outlines
 


### PR DESCRIPTION
Using the standard keywords allows tools such as `lisp-mnt.el` to extract metadata.

I maintain the Emacsmirror (https://github.com/emacsmirror) and will probably start mirroring your version instead of Carsten's. Just to be sure: do you have Carsten's blessing?
