### PR TITLE
Fix "before first heading" error when running outline-cycle

### DIFF
--- a/outline-magic.el
+++ b/outline-magic.el
@@ -267,7 +267,13 @@ them set by set, separated by a nil element.  See the example for
 	(setq this-command 'outline-cycle-showall))
        (t
 	;; Default action: go to overview
-	(hide-sublevels 1)
+	(let ((toplevel (cond
+			 (current-prefix-arg (prefix-numeric-value current-prefix-arg))
+			 ((save-excursion (beginning-of-line)
+					  (looking-at outline-regexp))
+			  (max 1 (funcall outline-level)))
+			 (t 1))))
+	  (hide-sublevels toplevel))
 	(message "OVERVIEW")
 	(setq this-command 'outline-cycle-overview))))
 


### PR DESCRIPTION
In some files (e.g. outline-magic.el itself), when the point is at the
beginning of the buffer and I run ‘outline-cycle’, the whole buffer gets
hidden. Subsequent runs of ‘outline-cycle’ fail and everything remains
hidden. The failure is caused by (error “before first heading”) called
from `outline-back-to-heading`.

The reason for this error is that in some files or modes, the top-level
outline headings do not have a level of 1 but some higher number. The
`hide-sublevels` command tries to "find" headings of level 1 and it
fails. In this patch, the level of the top-level heading is determined
the same way as in the outline-mode and then `hide-sublevels' is called
with the appropriate level as the parameter.

The error happens and the patch was tested in GNU Emacs 24.3.1
(x86_64-pc-linux-gnu, GTK+ Version 3.4.2) of 2013-04-13 on trouble,
modified by Debian.
