### PR TITLE
Clear current-prefix-argument from outline-cycle subcall

### DIFF
--- a/outline-magic.el
+++ b/outline-magic.el
@@ -237,7 +237,8 @@ them set by set, separated by a nil element.  See the example for
     ; Run `outline-cycle' as if at the top of the buffer.
     (save-excursion
       (goto-char (point-min))
-      (outline-cycle nil)))
+			(let ((current-prefix-argument nil))
+      (outline-cycle nil))))
 
    (t
     (cond


### PR DESCRIPTION
When called with a C-u prefix argument, outline-cycle makes a sub-
call to (outline-cycle nil). The intention is presumably to
call outline-cycle without a prefix argument, but unfortunately
the current-prefix-argument persists in the subcall. This can
cause errors later in determining how many sub-levels should be
hidden. In particular, this can cause an error when folding elisp.

This patch provides one way of fixing the behaviour so that
current-prefix-arg does not persist in the subcall.