### PR TITLE
Modify `outline-move-subtree-down`

### DIFF
--- a/outline-magic.el
+++ b/outline-magic.el
@@ -351,7 +351,6 @@ Essentially a much simplified version of `next-line'."
   "Move the currrent subtree down past ARG headlines of the same level."
   (interactive "p")
   (let* ((headers (or arg 1))
-        (re (concat "^" outline-regexp))
 	(movfunc (if (> headers 0) 'outline-get-next-sibling
 		   'outline-get-last-sibling))
 	(ins-point (make-marker))

--- a/outline-magic.el
+++ b/outline-magic.el
@@ -356,6 +356,9 @@ Essentially a much simplified version of `next-line'."
 		   'outline-get-last-sibling))
 	(ins-point (make-marker))
 	(cnt (abs headers))
+	(folded (save-match-data
+		  (outline-end-of-heading)
+		  (outline-invisible-p)))
 	beg end txt)
     ;; Select the tree
     (outline-back-to-heading)
@@ -379,6 +382,7 @@ Essentially a much simplified version of `next-line'."
     (delete-region beg end)
     (insert txt)
     (goto-char ins-point)
+    (if folded (outline-hide-subtree))
     (move-marker ins-point nil)))
 
 ;;; Promotion and Demotion


### PR DESCRIPTION
I'm sorry for my poor English.  In addition, I am not familiar with Emacs Lisp.  So, if this PR is not suitable, please discard.

The function `outline-move-subtree-down` defined in `outline-magic.el` expands subtrees after moving down (also `outline-move-subtree-up` does).  That is why I modify `outline-move-subtree-down`.

Thank you,